### PR TITLE
Update alg_traits.jl

### DIFF
--- a/src/alg_traits.jl
+++ b/src/alg_traits.jl
@@ -119,6 +119,17 @@ Defaults to false.
 requiresconstraints(opt) = false
 
 """
+requiresderivative(opt)
+
+Trait declaration for whether an optimizer
+requires derivatives specified in
+`cons` in `OptimizationProblem`.
+
+Defaults to false.
+"""
+requiresderivative(opt) = false
+
+"""
 allowscallback(opt)
 
 Trait declaration for whether an optimizer


### PR DESCRIPTION
Added trait for checking if OptimizationFunction is used for derivative-based optimizers #711

I added the requiresderivative trait to check if the user is requiring derivatives in optimization and is using the OptimizationFunction as an argument to OptimizationProblem.